### PR TITLE
Fix button text on beat saber 0.13.2

### DIFF
--- a/BeatSaber/BeatSaberUIExtensions.cs
+++ b/BeatSaber/BeatSaberUIExtensions.cs
@@ -18,8 +18,12 @@ namespace CustomUI.BeatSaber
         #region Button Extensions
         public static void SetButtonText(this Button _button, string _text)
         {
-            if (_button.GetComponentInChildren<TextMeshProUGUI>() != null)
-                _button.GetComponentInChildren<TextMeshProUGUI>().text = _text;
+            Polyglot.LocalizedTextMeshProUGUI localizer = _button.GetComponentInChildren<Polyglot.LocalizedTextMeshProUGUI>();
+            if (localizer != null)
+                GameObject.Destroy(localizer);
+            TextMeshProUGUI tmpUgui = _button.GetComponentInChildren<TextMeshProUGUI>();
+            if (tmpUgui != null)
+                tmpUgui.text = _text;
         }
 
         public static void SetButtonTextSize(this Button _button, float _fontSize)

--- a/CustomUI.csproj
+++ b/CustomUI.csproj
@@ -41,6 +41,7 @@
     </Reference>
     <Reference Include="Assembly-CSharp" />
     <Reference Include="IllusionPlugin" />
+    <Reference Include="Polyglot.Scripts" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
There's some new localization code that overrides the text we set. This code simply destroys the localization component before setting the text.