### PR TITLE
Fixes

### DIFF
--- a/GameplaySettings/GameplaySettingsTypes.cs
+++ b/GameplaySettings/GameplaySettingsTypes.cs
@@ -317,7 +317,7 @@ namespace CustomUI.GameplaySettings
 
             //This magical nonsense is courtesy of Taz and his SettingsUI class
             ListSettingsController volume = gameObject.GetComponent<ListSettingsController>();
-            multiSelectController = (ListViewController)ReflectionUtil.CopyComponent(volume, typeof(ListSettingsController), typeof(ListViewController), gameObject);
+            multiSelectController = (ListViewController)ReflectionUtil.CopyComponent(volume, typeof(ListSettingsController), typeof(ListViewController), gameObject, false);
             UnityEngine.Object.DestroyImmediate(volume);
 
             multiSelectController.applyImmediately = true;

--- a/Settings/SubMenu.cs
+++ b/Settings/SubMenu.cs
@@ -100,7 +100,7 @@ namespace CustomUI.Settings
             (decBg.transform as RectTransform).localScale *= new Vector2(0.8f, 0.8f);
 
             ListSettingsController volume = newSettingsObject.GetComponent<ListSettingsController>();
-            T newListSettingsController = (T)ReflectionUtil.CopyComponent(volume, typeof(ListSettingsController), typeof(T), newSettingsObject);
+            T newListSettingsController = (T)ReflectionUtil.CopyComponent(volume, typeof(ListSettingsController), typeof(T), newSettingsObject, false);
             MonoBehaviour.DestroyImmediate(volume);
 
             var tmpText = newSettingsObject.GetComponentInChildren<TMP_Text>();
@@ -134,7 +134,7 @@ namespace CustomUI.Settings
             BeatSaberUI.AddHintText(valueText.rectTransform, hintText);
 
             ListSettingsController volume = newSettingsObject.GetComponent<ListSettingsController>();
-            T newListSettingsController = (T)ReflectionUtil.CopyComponent(volume, typeof(ListSettingsController), typeof(T), newSettingsObject);
+            T newListSettingsController = (T)ReflectionUtil.CopyComponent(volume, typeof(ListSettingsController), typeof(T), newSettingsObject, false);
             MonoBehaviour.DestroyImmediate(volume);
 
             var tmpText = newSettingsObject.GetComponentInChildren<TMP_Text>();
@@ -163,7 +163,7 @@ namespace CustomUI.Settings
             (decBg.transform as RectTransform).localScale *= new Vector2(0.8f, 0.8f);
 
             SwitchSettingsController volume = newSettingsObject.GetComponent<SwitchSettingsController>();
-            T newToggleSettingsController = (T)ReflectionUtil.CopyComponent(volume, typeof(SwitchSettingsController), typeof(T), newSettingsObject);
+            T newToggleSettingsController = (T)ReflectionUtil.CopyComponent(volume, typeof(SwitchSettingsController), typeof(T), newSettingsObject, false);
             MonoBehaviour.DestroyImmediate(volume);
 
             var tmpText = newSettingsObject.GetComponentInChildren<TMP_Text>();

--- a/Settings/ViewControllers.cs
+++ b/Settings/ViewControllers.cs
@@ -45,6 +45,12 @@ namespace CustomUI.Settings
 
         bool lastValue;
 
+        protected override void OnEnable()
+        {
+            if (IsInitialized)
+                base.OnEnable();
+        }
+
         protected override bool GetInitValue()
         {
             bool value = false;
@@ -79,9 +85,9 @@ namespace CustomUI.Settings
 
         public void Init()
         {
-            OnEnable();
             OnDisable();
             IsInitialized = true;
+            OnEnable();
         }
     }
 
@@ -207,6 +213,12 @@ namespace CustomUI.Settings
 
         private bool _hasInited;
 
+        protected override void OnEnable()
+        {
+            if (IsInitialized)
+                base.OnEnable();
+        }
+
         protected override void GetInitValues(out int idx, out int numberOfElements)
         {
             numberOfElements = 2;
@@ -251,9 +263,9 @@ namespace CustomUI.Settings
 
         public void Init()
         {
-            OnEnable();
             OnDisable();
             IsInitialized = true;
+            OnEnable();
         }
     }
 
@@ -272,6 +284,12 @@ namespace CustomUI.Settings
         public bool IsInitialized { get; set; } = false;
 
         int lastidx;
+
+        protected override void OnEnable()
+        {
+            if (IsInitialized)
+                base.OnEnable();
+        }
 
         protected override void GetInitValues(out int idx, out int numberOfElements)
         {
@@ -320,9 +338,9 @@ namespace CustomUI.Settings
 
         public void Init()
         {
-            OnEnable();
             OnDisable();
             IsInitialized = true;
+            OnEnable();
         }
     }
 
@@ -337,7 +355,13 @@ namespace CustomUI.Settings
         public bool IsInitialized { get; set; } = false;
 
         int lastidx;
-        
+
+        protected override void OnEnable()
+        {
+            if (IsInitialized)
+                base.OnEnable();
+        }
+
         protected override void GetInitValues(out int idx, out int numberOfElements)
         {
             numberOfElements = values.Count;
@@ -370,9 +394,9 @@ namespace CustomUI.Settings
 
         public void Init()
         {
-            OnEnable();
             OnDisable();
             IsInitialized = true;
+            OnEnable();
         }
     }
 

--- a/Utilities/ReflectionUtil.cs
+++ b/Utilities/ReflectionUtil.cs
@@ -137,7 +137,7 @@ namespace CustomUI.Utilities
         }
 
         //(Created by taz?) Copies a component to a destination object, keeping all its field values?
-        public static Behaviour CopyComponent(Behaviour original, Type originalType, Type overridingType, GameObject destination)
+        public static Behaviour CopyComponent(Behaviour original, Type originalType, Type overridingType, GameObject destination, bool toggleEnabled = true)
         {
             Behaviour copy = null;
 
@@ -149,8 +149,9 @@ namespace CustomUI.Utilities
             {
 
             }
-
-            copy.enabled = false;
+            
+            if (toggleEnabled)
+                copy.enabled = false;
 
             //Copy types of super classes as well as our class
             Type type = originalType;
@@ -160,7 +161,9 @@ namespace CustomUI.Utilities
                 type = type.BaseType;
             }
 
-            copy.enabled = true;
+            if (toggleEnabled)
+                copy.enabled = true;
+
             return copy;
         }
 


### PR DESCRIPTION
Update copying of List/Switch subclassed types to not toggle enabled, this prevents Bahviour trying to enable/disable on an object in non-initialized state.
Add OnEnable override to List/Switch subclassed types, to prevent enabling of non-initialized object.
Update Init for List/Switch subclassed types to leave object in a default enabled state.

The above fixes the 2 NullExceptions, and ArgumentException (Index out of Range) being thrown.
Also puts the control in a usable state after Init.